### PR TITLE
Add custom domain support for ColorMe Shop

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,25 @@
 - 環境変数ACCOUNTで指定されたカラーミーショップ店舗の商品を直接カートに投入するリンクを構成するリダイレクタです
 
 ## Usage
-環境変数としてACCOUNTにカラーミーショップのIDを指定しリダイレクタを起動します。
+環境変数としてACCOUNTにカラーミーショップのIDまたは独自ドメインを指定しリダイレクタを起動します。
 
+### ドメイン設定
+- **デフォルトドメイン**: `ACCOUNT=hideack3` → `hideack3.shop-pro.jp`
+- **独自ドメイン**: `ACCOUNT=www.example.com` → `www.example.com`
+
+### アクセス方法
 - https://(デプロイ先)/(カラーミーショップ商品ID)
 
 上記リンクを経由することで該当リンクから直接ショッピングカートへ商品を投入することができます。
+
+### Examples
+```bash
+# デフォルトドメインの場合
+ACCOUNT=hideack3 npm start
+
+# 独自ドメインの場合
+ACCOUNT=www.example.com npm start
+```
 
 ## heroku
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/hideack/colorme-add-to-cart)

--- a/app.js
+++ b/app.js
@@ -10,14 +10,17 @@ module.exports = fastify(async function (fastify, opts) {
   })
 
   const ACCOUNT = process.env.ACCOUNT || 'hideack3';
+  // Auto-detect custom domain vs shop-pro.jp subdomain
+  const domain = ACCOUNT.includes('.') ? ACCOUNT : `${ACCOUNT}.shop-pro.jp`;
 
   fastify.get('/:product', (req, reply) => {
     fastify.log.info(req.params);
 
     fastify.log.info(`Account: ${ACCOUNT}`)
+    fastify.log.info(`Domain: ${domain}`)
     fastify.log.info(`Product ID: ${req.params.product}`)
 
-    reply.view('/ejs/redirect.ejs', { account: ACCOUNT , product: req.params.product})
+    reply.view('/ejs/redirect.ejs', { domain: domain , product: req.params.product})
   })
 
   // Declare a route

--- a/ejs/redirect.ejs
+++ b/ejs/redirect.ejs
@@ -3,7 +3,7 @@
     <script src="https://code.jquery.com/jquery-3.4.1.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
   </head>
   <body>
-    <script type='text/javascript' src='https://<%= account %>.shop-pro.jp/?mode=cartjs&pid=<%= product %>&style=basic&name=n&img=n&expl=n&stock=n&price=n&inq=n&sk=n&w=1' charset='euc-jp'></script>
+    <script type='text/javascript' src='https://<%= domain %>/?mode=cartjs&pid=<%= product %>&style=basic&name=n&img=n&expl=n&stock=n&price=n&inq=n&sk=n&w=1' charset='euc-jp'></script>
     <script type='text/javascript'>
       $('.cartjs_box').hide()
       $('form').submit();

--- a/test/services/example.test.js
+++ b/test/services/example.test.js
@@ -3,7 +3,7 @@
 const { test } = require('tap')
 const { build } = require('../helper')
 
-test('product redirect is loaded', (t) => {
+test('product redirect is loaded with default domain', (t) => {
   t.plan(3)
   const app = build(t)
 
@@ -13,6 +13,28 @@ test('product redirect is loaded', (t) => {
     t.error(err)
     t.ok(res.payload.includes('hideack3.shop-pro.jp'))
     t.ok(res.payload.includes('test-product-123'))
+  })
+})
+
+test('product redirect works with custom domain', (t) => {
+  t.plan(4)
+
+  // Override environment variable for this test
+  const originalAccount = process.env.ACCOUNT
+  process.env.ACCOUNT = 'www.example.com'
+
+  const app = build(t)
+
+  app.inject({
+    url: '/test-product-456'
+  }, (err, res) => {
+    t.error(err)
+    t.ok(res.payload.includes('www.example.com'))
+    t.notOk(res.payload.includes('www.example.com.shop-pro.jp'))
+    t.ok(res.payload.includes('test-product-456'))
+
+    // Restore original environment variable
+    process.env.ACCOUNT = originalAccount
   })
 })
 


### PR DESCRIPTION
Features:
- Auto-detect custom domains vs shop-pro.jp subdomains
- ACCOUNT="hideack3" → hideack3.shop-pro.jp (default)
- ACCOUNT="www.example.com" → www.example.com (custom domain)

Changes:
- app.js: Add domain detection logic using dot presence
- redirect.ejs: Use domain variable instead of account.shop-pro.jp
- tests: Add comprehensive test cases for both domain types
- README.md: Document custom domain usage with examples

Implementation uses method 1 (auto-detection) for simplicity: const domain = ACCOUNT.includes('.') ? ACCOUNT : `${ACCOUNT}.shop-pro.jp`;